### PR TITLE
[WIP] (doc) [contribution] clarify why merge before PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 1. Make commits to your feature branch.
 1. Pull Request
     - If you want to start a conversation about the feature   you're working on, submit a pull request to origin   master with [WIP]  prefixed.
-    - If you want to submit a pull request to merge your feature branch's code into master, make sure you've updated your feature branch by merging master's changes.
+    - If you want to submit a pull request to merge your feature branch's code into master, first make sure your feature branch is up-to-date by merging master's changes into yours.
     - Include a description of your changes.
 1. Your pull request will be reviewed by another maintainer. The point of code reviews is to help keep the codebase clean and of high quality and, equally as important, to help you grow as a programmer. If your code reviewer requests you make a change you don't understand, ask them why.
 1. Fix any issues raised by your code reviwer, and push your fixes.


### PR DESCRIPTION
Clarifying what merging from master before we PR does.
I'm just going to slap "keep your feature branch up-to-date" in all the places this step is mentioned and call this PR done. feel free to add other edits.

wait.. doesn't Github not allow us to PR with an outdated branch anyway?

it's just on merging locally that we need to remember to pull and merge first. Please refresh my memory.